### PR TITLE
Fix median calculation

### DIFF
--- a/src/utils/compute_median.cairo
+++ b/src/utils/compute_median.cairo
@@ -2,7 +2,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le
 
 const TIMESTAMP_COUNT = 11;
-const TIMESTAMP_MEDIAN_INDEX = 6;
+const TIMESTAMP_MEDIAN_INDEX = 5;
 
 func compute_timestamps_median{range_check_ptr}(timestamp_array : felt*) -> (
         median_value : felt

--- a/src/utils/compute_median_test.cairo
+++ b/src/utils/compute_median_test.cairo
@@ -9,7 +9,7 @@ func test_compute_timestamps_median{range_check_ptr}() {
     tempvar timestamps: felt* = new (10, 16, 8, 0, 3, 3, 7, 20, 0, 4, 10);
     let (median) = compute_timestamps_median(timestamps);
 
-    assert median = 8;
+    assert median = 7;
 
     return ();
 }


### PR DESCRIPTION
The median should be the element at index 5 of the sorted array.