### PR TITLE
Verify bits_to_target

### DIFF
--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -488,7 +488,9 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
     let (expected_target) = bits_to_target(bits);
 
     let is_greater_than_2 = (2 - quotient) * (1 - quotient) * quotient;
-    if (is_greater_than_2 != 0) {
+    if (is_greater_than_2 == 0) {
+        return (bits=bits);
+    } else {
         // if exponent >= 3 we check that
         // ((target & (threshold * 0xffffff)) - expected_target) == 0
         let (threshold) = pow(BYTE, quotient - 3);
@@ -497,8 +499,6 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
 
         let diff = masked_target - expected_target;
         assert diff = 0;
-        return (bits=bits);
-    } else {
         return (bits=bits);
     }
 }

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -489,16 +489,18 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
 
     let is_less_than_3 = is_le_felt(quotient, 3);
     if (is_less_than_3 == 0) {
-        tempvar range_check_ptr = range_check_ptr;
         // if exponent >= 3 we check that
-        // (target - expected_target) <= 256 ** (exponent - 3)
+        // ((target & (threshold * 0xffffff)) - expected_target) == 0
         let (threshold) = pow(BYTE, quotient - 3);
-        assert_le_felt(target - expected_target, threshold);
-    } else {
-        tempvar range_check_ptr = range_check_ptr;
-    }
+        let mask = threshold * 0xffffff;
+        let (masked_target) = bitwise_and(target, mask);
 
-    return (bits=bits);
+        let diff = masked_target - expected_target;
+        assert diff = 0;
+        return (bits=bits);
+    } else {
+        return (bits=bits);
+    }
 }
 
 // Convert a felt to a Uint256

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -191,9 +191,9 @@ func bits_to_target{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(bits) -> (tar
     // Decode the 4 bytes of `bits` into exponent and significand.
     // There's 1 byte for the exponent followed by 3 bytes for the significand
 
-    // To do so, first we need a mask with the first 8 bites:
+    // To do so, first we need a mask with the first 8 bits:
     const MASK_BITS_TO_SHIFT = 0xFF000000;
-    // Then, using a bitwise and to get only the first 8 bites.
+    // Then, using a bitwise and to get only the first 8 bits.
     let (bits_to_shift) = bitwise_and(bits, MASK_BITS_TO_SHIFT);
     // And finally, do the shifts
     let exponent = bits_to_shift / 0x1000000;
@@ -476,11 +476,11 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
     %}
 
     // We need to perform 24 right-shifts
-    // So we need only the 8 most significative bites.
+    // So we need only the 8 most significative bits.
 
-    // To do so, first we need a mask with the first 8 bites:
+    // To do so, first we need a mask with the first 8 bits:
     const MASK_BITS_TO_SHIFT = 0xFF000000;
-    // Then, using a bitwise and to get only the first 8 bites.
+    // Then, using a bitwise and to get only the first 8 bits.
     let (bits_to_shift) = bitwise_and(bits, MASK_BITS_TO_SHIFT);
     // And finally, do the shifts
     let quotient = bits_to_shift / 0x1000000;

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -477,7 +477,7 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
     // give us the same result as the target passed as parameter to this
     // function.
     let (expected_target) = bits_to_target(bits);
-    assert expected_target = target;
+    assert_le(target - expected_target, 0x1000000000000000);
 
     return (bits=bits);
 }

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -205,8 +205,8 @@ func bits_to_target{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(bits) -> (tar
     // when the exponent is greater than 3.
     // And it is `significand` shifted `exponent` times to the right when
     // it is less than 3.
-    let is_greater_than_3 = (2 - exponent) * (1 - exponent) * exponent;
-    if (is_greater_than_3 == 0) {
+    let is_greater_than_2 = (2 - exponent) * (1 - exponent) * exponent;
+    if (is_greater_than_2 == 0) {
         let (shift) = pow(BYTE, 3 - exponent);
         local target;
         %{ ids.target = ids.significand // ids.shift %}
@@ -487,8 +487,8 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
 
     let (expected_target) = bits_to_target(bits);
 
-    let is_greater_than_3 = (2 - quotient) * (1 - quotient) * quotient;
-    if (is_greater_than_3 == 0) {
+    let is_greater_than_2 = (2 - quotient) * (1 - quotient) * quotient;
+    if (is_greater_than_2 == 0) {
         // if exponent >= 3 we check that
         // ((target & (threshold * 0xffffff)) - expected_target) == 0
         let (threshold) = pow(BYTE, quotient - 3);

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -445,7 +445,7 @@ func adjust_difficulty{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
 
 // Calculate bits from target
 //
-func target_to_bits{range_check_ptr}(target) -> (bits: felt) {
+func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (bits: felt) {
     alloc_locals;
     local bits;
     
@@ -471,11 +471,15 @@ func target_to_bits{range_check_ptr}(target) -> (bits: felt) {
             return compact | size << 24
 
         ids.bits = target_to_bits(ids.target)
-        print(f'bits: {ids.bits}')
-        print(f'target: {ids.target}')
     %}
+ 
+    // Checks that calculating the target from the bits we got in the hint
+    // give us the same result as the target passed as parameter to this
+    // function.
+    let (expected_target) = bits_to_target(bits);
+    assert expected_target = target;
 
-    return (bits,);
+    return (bits=bits);
 }
 
 

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -204,9 +204,9 @@ func bits_to_target{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(bits) -> (tar
     // The target is the `significand` shifted `exponent` times to the left
     // when the exponent is greater than 3.
     // And it is `significand` shifted `exponent` times to the right when
-    // it is less or equal to 3.
-    let is_less_than_3 = is_le_felt(exponent, 3);
-    if (is_less_than_3 == 1) {
+    // it is less than 3.
+    let is_greater_than_3 = (2 - exponent) * (1 - exponent) * exponent;
+    if (is_greater_than_3 == 0) {
         let (shift) = pow(BYTE, 3 - exponent);
         local target;
         %{ ids.target = ids.significand // ids.shift %}
@@ -487,8 +487,8 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
 
     let (expected_target) = bits_to_target(bits);
 
-    let is_less_than_3 = is_le_felt(quotient, 3);
-    if (is_less_than_3 == 0) {
+    let is_greater_than_3 = (2 - quotient) * (1 - quotient) * quotient;
+    if (is_greater_than_3 == 0) {
         // if exponent >= 3 we check that
         // ((target & (threshold * 0xffffff)) - expected_target) == 0
         let (threshold) = pow(BYTE, quotient - 3);

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -488,7 +488,7 @@ func target_to_bits{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(target) -> (b
     let (expected_target) = bits_to_target(bits);
 
     let is_greater_than_2 = (2 - quotient) * (1 - quotient) * quotient;
-    if (is_greater_than_2 == 0) {
+    if (is_greater_than_2 != 0) {
         // if exponent >= 3 we check that
         // ((target & (threshold * 0xffffff)) - expected_target) == 0
         let (threshold) = pow(BYTE, quotient - 3);

--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -208,7 +208,8 @@ func bits_to_target{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(bits) -> (tar
     let is_less_than_3 = is_le_felt(exponent, 3);
     if (is_less_than_3 == 1) {
         let (shift) = pow(BYTE, 3 - exponent);
-        let (target, _rem) = unsigned_div_rem(significand, shift);
+        local target;
+        %{ ids.target = ids.significand // ids.shift %}
         return (target=target);
     } else {
         let (shift) = pow(BYTE, exponent - 3);

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -62,16 +62,6 @@ func test_bits_to_target_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}()
     return ();
 }
 
-// TODO: fix bits_to_target to handle negative targets.
-// @external
-// func test_bits_to_target_works_with_negative{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
-//     let bits = 0x04923456;
-//     let expected_target = -0x12345600;
-//     let (result) = bits_to_target(bits);
-//     assert result = expected_target;
-//     return ();
-// }
-
 @external
 func test_target_to_bits_works1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let expected_bits = 0x181bc330;
@@ -98,13 +88,3 @@ func test_target_to_bits_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}()
     assert result = expected_bits;
     return ();
 }
-
-// TODO: fix target_to_bits to handle negative targets.
-// @external
-// func test_target_to_bits_works_with_negative{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
-//     let expected_bits = 0x04923456;
-//     let target = -0x12345600;
-//     let (result) = target_to_bits(target);
-//     assert result = expected_bits;
-//     return ();
-// }

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -9,7 +9,7 @@ from block_header import bits_to_target, target_to_bits
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 @external
-func test_bits_to_target_small_works1{range_check_ptr}() {
+func test_bits_to_target_small_works1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x01003456;
     let expected_target = 0x00;
     let (result) = bits_to_target(bits);
@@ -18,7 +18,7 @@ func test_bits_to_target_small_works1{range_check_ptr}() {
 }
 
 @external
-func test_bits_to_target_small_works2{range_check_ptr}() {
+func test_bits_to_target_small_works2{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x01123456;
     let expected_target = 0x12;
     let (result) = bits_to_target(bits);
@@ -27,7 +27,7 @@ func test_bits_to_target_small_works2{range_check_ptr}() {
 }
 
 @external
-func test_bits_to_target_small_works3{range_check_ptr}() {
+func test_bits_to_target_small_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x02008000;
     let expected_target = 0x80;
     let (result) = bits_to_target(bits);
@@ -36,7 +36,7 @@ func test_bits_to_target_small_works3{range_check_ptr}() {
 }
 
 @external
-func test_bits_to_target_works1{range_check_ptr}() {
+func test_bits_to_target_works1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x181bc330;
     let expected_target = 0x1bc330000000000000000000000000000000000000000000;
     let (result) = bits_to_target(bits);
@@ -45,7 +45,7 @@ func test_bits_to_target_works1{range_check_ptr}() {
 }
 
 @external
-func test_bits_to_target_works2{range_check_ptr}() {
+func test_bits_to_target_works2{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x05009234;
     let expected_target = 0x92340000;
     let (result) = bits_to_target(bits);
@@ -54,7 +54,7 @@ func test_bits_to_target_works2{range_check_ptr}() {
 }
 
 @external
-func test_bits_to_target_works3{range_check_ptr}() {
+func test_bits_to_target_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let bits = 0x04123456;
     let expected_target = 0x12345600;
     let (result) = bits_to_target(bits);
@@ -64,11 +64,11 @@ func test_bits_to_target_works3{range_check_ptr}() {
 
 // TODO: fix bits_to_target to handle negative targets.
 // @external
-// func test_bits_to_target_works_with_negative{range_check_ptr}() {
+// func test_bits_to_target_works_with_negative{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
 //     let bits = 0x04923456;
 //     let expected_target = -0x12345600;
 //     let (result) = bits_to_target(bits);
-//     assert result  = expected_target;
+//     assert result = expected_target;
 //     return ();
 // }
 

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -1,13 +1,41 @@
 %lang starknet
 
 from block_header import bits_to_target, target_to_bits
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+@external
+func test_bits_to_target_small_works1{range_check_ptr}() {
+    let bits = 0x01003456;
+    let expected_target = 0x00;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_small_works2{range_check_ptr}() {
+    let bits = 0x01123456;
+    let expected_target = 0x12;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_small_works3{range_check_ptr}() {
+    let bits = 0x02008000;
+    let expected_target = 0x80;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
 
 @external
 func test_bits_to_target_works1{range_check_ptr}() {
     let bits = 0x181bc330;
     let expected_target = 0x1bc330000000000000000000000000000000000000000000;
     let (result) = bits_to_target(bits);
-    assert result  = expected_target;
+    assert result = expected_target;
     return ();
 }
 
@@ -16,7 +44,7 @@ func test_bits_to_target_works2{range_check_ptr}() {
     let bits = 0x05009234;
     let expected_target = 0x92340000;
     let (result) = bits_to_target(bits);
-    assert result  = expected_target;
+    assert result = expected_target;
     return ();
 }
 
@@ -25,15 +53,53 @@ func test_bits_to_target_works3{range_check_ptr}() {
     let bits = 0x04123456;
     let expected_target = 0x12345600;
     let (result) = bits_to_target(bits);
-    assert result  = expected_target;
+    assert result = expected_target;
+    return ();
+}
+
+// TODO: fix bits_to_target to handle negative targets.
+// @external
+// func test_bits_to_target_works_with_negative{range_check_ptr}() {
+//     let bits = 0x04923456;
+//     let expected_target = -0x12345600;
+//     let (result) = bits_to_target(bits);
+//     assert result  = expected_target;
+//     return ();
+// }
+
+@external
+func test_target_to_bits_works1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x181bc330;
+    let target = 0x1bc330000000000000000000000000000000000000000000;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
     return ();
 }
 
 @external
-func test_bits_to_target_works_with_negative{range_check_ptr}() {
-    let bits = 0x04923456;
-    let expected_target = -0x12345600;
-    let (result) = bits_to_target(bits);
-    assert result  = expected_target;
+func test_target_to_bits_works2{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x05009234;
+    let target = 0x92340000;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
     return ();
 }
+
+@external
+func test_target_to_bits_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x04123456;
+    let target = 0x12345600;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
+    return ();
+}
+
+// TODO: fix target_to_bits to handle negative targets.
+// @external
+// func test_target_to_bits_works_with_negative{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+//     let expected_bits = 0x04923456;
+//     let target = -0x12345600;
+//     let (result) = target_to_bits(target);
+//     assert result = expected_bits;
+//     return ();
+// }

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -1,0 +1,39 @@
+%lang starknet
+
+from block_header import bits_to_target, target_to_bits
+
+@external
+func test_bits_to_target_works1{range_check_ptr}() {
+    let bits = 0x181bc330;
+    let expected_target = 0x1bc330000000000000000000000000000000000000000000;
+    let (result) = bits_to_target(bits);
+    assert result  = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_works2{range_check_ptr}() {
+    let bits = 0x05009234;
+    let expected_target = 0x92340000;
+    let (result) = bits_to_target(bits);
+    assert result  = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_works3{range_check_ptr}() {
+    let bits = 0x04123456;
+    let expected_target = 0x12345600;
+    let (result) = bits_to_target(bits);
+    assert result  = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_works_with_negative{range_check_ptr}() {
+    let bits = 0x04923456;
+    let expected_target = -0x12345600;
+    let (result) = bits_to_target(bits);
+    assert result  = expected_target;
+    return ();
+}

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -1,3 +1,8 @@
+//
+// To run only this test suite use:
+// protostar test --cairo-path=./src target src/block/test_target.cairo
+//
+
 %lang starknet
 
 from block_header import bits_to_target, target_to_bits

--- a/src/block/test_target.cairo
+++ b/src/block/test_target.cairo
@@ -63,6 +63,33 @@ func test_bits_to_target_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}()
 }
 
 @external
+func test_bits_to_target_works4{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let bits = 0x1d00ffff;
+    let expected_target = 0x00000000ffff0000000000000000000000000000000000000000000000000000;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_works5{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let bits = 0x1c0d3142;
+    let expected_target = 0x000000000d314200000000000000000000000000000000000000000000000000;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
+
+@external
+func test_bits_to_target_works6{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let bits = 0x1707a429;
+    let expected_target = 0x00000000000000000007a4290000000000000000000000000000000000000000;
+    let (result) = bits_to_target(bits);
+    assert result = expected_target;
+    return ();
+}
+
+@external
 func test_target_to_bits_works1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let expected_bits = 0x181bc330;
     let target = 0x1bc330000000000000000000000000000000000000000000;
@@ -84,6 +111,33 @@ func test_target_to_bits_works2{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}()
 func test_target_to_bits_works3{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
     let expected_bits = 0x04123456;
     let target = 0x12345600;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
+    return ();
+}
+
+@external
+func test_target_to_bits_works4{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x1d00ffff;
+    let target = 0x00000000ffff0000000000000000000000000000000000000000000000000000;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
+    return ();
+}
+
+@external
+func test_target_to_bits_works5{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x1c0d3142;
+    let target = 0x000000000d314200000000000000000000000000000000000000000000000000;
+    let (result) = target_to_bits(target);
+    assert result = expected_bits;
+    return ();
+}
+
+@external
+func test_target_to_bits_works6{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
+    let expected_bits = 0x1707a429;
+    let target = 0x00000000000000000007a4290000000000000000000000000000000000000000;
     let (result) = target_to_bits(target);
     assert result = expected_bits;
     return ();


### PR DESCRIPTION
This PR adds:
- fixes to bits_to_target and target_to_bits to handle small exponents.
- Tests for both functions. The values were taken from this page https://learnmeabitcoin.com/technical/target  .
- Verifies that the output from target_to_bits is the expected value.