### PR TITLE
⚡️ use != 0 instead of == 1

### DIFF
--- a/src/serialize/serialize.cairo
+++ b/src/serialize/serialize.cairo
@@ -9,6 +9,7 @@
 // - https://github.com/mimblewimble/grin/blob/master/core/src/ser.rs
 
 from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.math import assert_le
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
@@ -404,7 +405,7 @@ func write_varint{writer: Writer, range_check_ptr, bitwise_ptr: BitwiseBuiltin*}
     }
 
     let source_is_8_bytes = is_le(BYTE ** 4, source);
-    if (source_is_8_bytes == 1) {
+    if (source_is_8_bytes != FALSE) {
         // This varint has 8 more bytes after the leading byte.
         write_uint8(0xff);
         write_uint64(source);
@@ -412,7 +413,7 @@ func write_varint{writer: Writer, range_check_ptr, bitwise_ptr: BitwiseBuiltin*}
     }
 
     let source_is_4_bytes = is_le(BYTE ** 2, source);
-    if (source_is_4_bytes == 1) {
+    if (source_is_4_bytes != FALSE) {
         // This varint has 4 more bytes after the leading byte.
         write_uint8(0xfe);
         write_uint32(source);
@@ -420,7 +421,7 @@ func write_varint{writer: Writer, range_check_ptr, bitwise_ptr: BitwiseBuiltin*}
     }
 
     let source_is_2_bytes = is_le(BYTE, source);
-    if (source_is_2_bytes == 1) {
+    if (source_is_2_bytes != FALSE) {
         // This varint has 2 more bytes after the leading byte.
         write_uint8(0xfd);
         write_uint16(source);

--- a/src/stark_verifier/crypto/random.cairo
+++ b/src/stark_verifier/crypto/random.cairo
@@ -12,7 +12,7 @@ from starkware.cairo.common.hash import HashBuiltin
 from starkware.cairo.common.hash_state import hash_finalize, hash_init, hash_update
 from starkware.cairo.common.math import assert_nn_le, assert_le
 from starkware.cairo.common.math_cmp import is_le
-from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
 from utils.pow2 import pow2

--- a/src/stark_verifier/crypto/random.cairo
+++ b/src/stark_verifier/crypto/random.cairo
@@ -193,7 +193,7 @@ func _draw_integers_loop{
     let bitwise_ptr = bitwise_ptr + BitwiseBuiltin.SIZE;
 
     let is_contained = contains(value, elements, index);
-    if (is_contained == 1) {
+    if (is_contained != FALSE) {
         return _draw_integers_loop(n_elements, elements, domain_size, index);
     }
 


### PR DESCRIPTION
## Description

In Cairo, it is more efficient to do `a !=0` instead of `a == 1` for boolean comparisons, there are some places in the code where we use `== 1`,

- Use != instead of == for boolean comparisons
- Use TRUE or FALSE instead of 0 or 1 for readability