### PR TITLE
Fix/err

### DIFF
--- a/src/headers_chain_proof/bridge_node.py
+++ b/src/headers_chain_proof/bridge_node.py
@@ -207,7 +207,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         if self.path.startswith('/reset'):
             print('>>>>>>>>>> RESET >>>>>>>>>>')
             leaf_nodes = []
-            return
+          
 
 
 if __name__ == '__main__':

--- a/src/stark_verifier/channel.cairo
+++ b/src/stark_verifier/channel.cairo
@@ -95,7 +95,7 @@ func read_pow_nonce{channel: Channel}() -> felt {
 }
 
 struct QueriesProof {
-    length : felt,  // TODO: this is unneccessary overhead. All paths of a BatchMerkleProof have the same length
+    length : felt,  // TODO: this is unnecessary overhead. All paths of a BatchMerkleProof have the same length
     digests : felt*,
 }
 


### PR DESCRIPTION
# Fix: Removed redundant return and corrected a typo

## Changes
1. **Redundant return removed**:
   - `src/headers_chain_proof/bridge_node.py:210`: Removed unnecessary `return` statement.
     - **Before**:
       ```python
       if self.path.startswith('/reset'):
           print('>>>>>>>>>> RESET >>>>>>>>>>')
           leaf_nodes = []
           return
       ```
     - **After**:
       ```python
       if self.path.startswith('/reset'):
           print('>>>>>>>>>> RESET >>>>>>>>>>')
           leaf_nodes = []
       ```

2. **Typo correction**:
   - `src/stark_verifier/channel.cairo:98`: "unneccessary" corrected to "unnecessary".

## Purpose
- Improved code clarity by removing redundant statements.
- Ensured documentation and code consistency with typo correction.
