### PR TITLE
Fix typographical errors

### DIFF
--- a/src/block/block_header.cairo
+++ b/src/block/block_header.cairo
@@ -255,7 +255,7 @@ func validate_prev_block_hash(context: BlockHeaderValidationContext) {
 func validate_proof_of_work{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(
     context: BlockHeaderValidationContext
 ) {
-    // Swap the endianess in the uint32 chunks of the hash
+    // Swap the endianness in the uint32 chunks of the hash
     let reader = init_reader(context.block_hash);
     let hash = read_bytes{reader=reader}(32);
 

--- a/src/chain_proof/main.py
+++ b/src/chain_proof/main.py
@@ -34,7 +34,7 @@ def felts_to_hash(felts):
     res = 0
     for i in range(8):
         felt = felts[i]
-        # Swap endianess
+        # Swap endianness
         felt = struct.unpack("<I", struct.pack(">I", felt))[0]
         res += pow(2**32, i) * felt
     return hex(res).replace('0x', '').zfill(64)

--- a/src/headers_chain_proof/main.py
+++ b/src/headers_chain_proof/main.py
@@ -34,7 +34,7 @@ def felts_to_hash(felts):
     res = 0
     for i in range(8):
         felt = felts[i]
-        # Swap endianess
+        # Swap endianness
         felt = struct.unpack("<I", struct.pack(">I", felt))[0]
         res += pow(2**32, i) * felt
     return hex(res).replace('0x', '').zfill(64)

--- a/src/stark_verifier/channel.cairo
+++ b/src/stark_verifier/channel.cairo
@@ -95,7 +95,7 @@ func read_pow_nonce{channel: Channel}() -> felt {
 }
 
 struct QueriesProof {
-    length : felt,  // TODO: this is unneccessary overhead. All paths of a BatchMerkleProof have the same length
+    length : felt,  // TODO: this is unnecessary overhead. All paths of a BatchMerkleProof have the same length
     digests : felt*,
 }
 

--- a/src/utils/benchmark_block.py
+++ b/src/utils/benchmark_block.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     cmd = f'cairo-compile src/chain_proof/main.cairo --cairo_path src --output {output_dir}/program.json'
     print(os.popen(cmd).read())  # In case there are compilation issues
     print('Done.')
-    print('Fetching utxos and setting up brige node and initial state...')
+    print('Fetching utxos and setting up bridge node and initial state...')
     # Copy genesis state.json into the output directory
     # also read the program_length from program.json
     # and add it to the state.json

--- a/src/utils/benchmark_block.py
+++ b/src/utils/benchmark_block.py
@@ -54,7 +54,7 @@ def felts_to_hash(felts):
     res = 0
     for i in range(8):
         felt = felts[i]
-        # Swap endianess
+        # Swap endianness
         felt = struct.unpack("<I", struct.pack(">I", felt))[0]
         res += pow(2**32, i) * felt
 

--- a/tests/unit/block/test_merkle_tree.cairo
+++ b/tests/unit/block/test_merkle_tree.cairo
@@ -1,4 +1,4 @@
-// Note that Bitcoin Core and most block explorers swap the endianess when displaying a hash
+// Note that Bitcoin Core and most block explorers swap the endianness when displaying a hash
 // So, we have to reverse the byte order to compute the merkle tree
 
 //


### PR DESCRIPTION
- Corrected "endianess" to "endianness" in comments.
- Fixed spelling errors like "unneccessary" to "unnecessary".
- Applied other minor typo corrections for improved clarity.
